### PR TITLE
pmash.c: Keep empty deps files

### DIFF
--- a/pmash.c
+++ b/pmash.c
@@ -392,10 +392,6 @@ main(int argc, char *argv[])
 
     if (depsfile) {
         fclose(fp);
-        // Don't keep empty deps files around.
-        if (!prq_count) {
-            insist(unlink(depsfile) != -1, depsfile);
-        }
     }
 
     return rc;


### PR DESCRIPTION
Keep empty dependency files if they are generated.

If the generated dependency file is removed, it can appear to "make"
that the dependency analysis wasn't done and thus needs to be redone.
But it is entirely possible that there are no dependencies
for a given circumance.  So we should keep an empty dependency file,
not delete it, to indicate "analysis was done and there are no
dependencies" and differentiate that from "analysis not yet done".

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>