### PR TITLE
Add --shell, --shellflags, and --multiline options

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,4 +260,21 @@ the recipe for each object file looks like this (simplified):
 Without .ONESHELL the mv command would run last and in its own shell
 so jobs.o.d would end up recording only the actions of mv, not gcc.
 
+## Per-Target Detailed Auditing with Pmaudit
+
+Let's say that you want to record detailed information about
+what was read and written for each make target.
+
+Here's one way to do that:
+
+% make --eval=.ONESHELL: SHELL=pmaudit .SHELLFLAGS='--multiline --json $@.json -c' > make.log 2>&1
+
+Here we are using pmaudit, which currently provides more options
+than pmash.
+We use its "--multiline" option to more accurately reflect how make
+normally runs commands (normally make runs a line at a time, and stops
+a command once any of them fail).
+We also use its "--json" option to record data to a JSON file - this
+provides much more information than the "-d" option.
+
 [*] With apologies for the implied classism and sexism :-)

--- a/pmaudit
+++ b/pmaudit
@@ -491,6 +491,17 @@ def main():
         metavar='FILE',
         help="save audit data in makefile format to FILE")
     parser.add_argument(
+        '--shell',
+        metavar='SHELL_COMMAND',
+        help="Name of shell to run (default=SHELL else /bin/sh)")
+    parser.add_argument(
+        '--shellflags',
+        metavar='SHELL_FLAGS',
+        help="Space-separated set of flags to pass to shell (default=-c)")
+    parser.add_argument(
+        '--multiline', action='store_true',
+        help="Separately run each line in the command")
+    parser.add_argument(
         '--custom', action='append',
         metavar='KEY_VALUE_PAIR',
         help="Include custom key=value pair in JSON results")
@@ -506,12 +517,23 @@ def main():
         else:
             opts = parser.parse_args()
             cfglog(opts.verbosity)
-            cmd = [os.getenv('SHELL', '/bin/sh')]
+            if opts.shell:
+                cmd = [opts.shell]
+            else:
+                cmd = [os.getenv('SHELL', '/bin/sh')]
             if opts.errexit:
                 cmd.append('-e')
             if opts.verbosity:
                 cmd.append('-x')
-            cmd += ['-c', opts.cmd]
+            if opts.shellflags:
+                cmd += opts.shellflags.split()
+            else:
+                cmd.append('-c')
+            if opts.multiline:
+                result = [cmd + [line] for line in opts.cmd.splitlines()]
+                cmd = result
+            else:
+                cmd.append(opts.cmd)
         if not opts.json and not opts.depsfile:  # Implement default save.
             opts.json = '%s.json' % PROG
         wdirs = []
@@ -524,7 +546,15 @@ def main():
             exclude_set |= {opts.depsfile}
         audit = PMAudit(wdirs, exclude=exclude_set)
         audit.start(flush_host=opts.flush_host, keep_going=opts.keep_going)
-        rc = subprocess.call(cmd)
+        if cmd and cmd[0] and isinstance(cmd[0], list):
+            for cmd_line in cmd: # Execute each line in sequence.
+                rc = subprocess.call(cmd_line)
+                # Stop if we get an error.  Note that "make" does this *even*
+                # when -k/--keep-going mode is enabled.
+                if rc != 0:
+                    break
+        else:
+            rc = subprocess.call(cmd)
         adb = audit.finish(cmd=opts.cmd or ' '.join(cmd))
         adb['CUSTOM'] = custom_results(opts.custom)
         if opts.depsfile:

--- a/pmaudit
+++ b/pmaudit
@@ -491,20 +491,18 @@ def main():
         metavar='FILE',
         help="save audit data in makefile format to FILE")
     parser.add_argument(
-        '--shell',
-        metavar='SHELL_COMMAND',
-        help="Name of shell to run (default=SHELL else /bin/sh)")
+        '--shell', default='/bin/sh',
+        help="name of shell to run (default=%(default)s)")
     parser.add_argument(
-        '--shellflags',
-        metavar='SHELL_FLAGS',
-        help="Space-separated set of flags to pass to shell (default=-c)")
+        '--shellflags', default='-c',
+        help="space-separated flags to pass to shell (default=%(default)s)")
     parser.add_argument(
         '--multiline', action='store_true',
-        help="Separately run each line in the command")
+        help="separately run each line in the command")
     parser.add_argument(
         '--custom', action='append',
         metavar='KEY_VALUE_PAIR',
-        help="Include custom key=value pair in JSON results")
+        help="include custom key=value pair in JSON results")
 
     if '--' in sys.argv or '-c' in sys.argv or '--cmd' in sys.argv:
         if '--' in sys.argv:
@@ -517,18 +515,12 @@ def main():
         else:
             opts = parser.parse_args()
             cfglog(opts.verbosity)
-            if opts.shell:
-                cmd = [opts.shell]
-            else:
-                cmd = [os.getenv('SHELL', '/bin/sh')]
             if opts.errexit:
                 cmd.append('-e')
             if opts.verbosity:
                 cmd.append('-x')
             if opts.shellflags:
                 cmd += opts.shellflags.split()
-            else:
-                cmd.append('-c')
             if opts.multiline:
                 result = [cmd + [line] for line in opts.cmd.splitlines()]
                 cmd = result

--- a/pmaudit
+++ b/pmaudit
@@ -511,10 +511,11 @@ def main():
             if '--' in cmd:
                 cmd.remove('--')
             assert not (opts.cmd or opts.errexit)
-            sys.stderr.write('+ %s\n' % ' '.join(cmd))
+            cmd = [cmd]
         else:
             opts = parser.parse_args()
             cfglog(opts.verbosity)
+            cmd = [opts.shell]
             if opts.errexit:
                 cmd.append('-e')
             if opts.verbosity:
@@ -525,7 +526,7 @@ def main():
                 result = [cmd + [line] for line in opts.cmd.splitlines()]
                 cmd = result
             else:
-                cmd.append(opts.cmd)
+                cmd = [cmd + [opts.cmd]]
         if not opts.json and not opts.depsfile:  # Implement default save.
             opts.json = '%s.json' % PROG
         wdirs = []
@@ -538,16 +539,13 @@ def main():
             exclude_set |= {opts.depsfile}
         audit = PMAudit(wdirs, exclude=exclude_set)
         audit.start(flush_host=opts.flush_host, keep_going=opts.keep_going)
-        if cmd and cmd[0] and isinstance(cmd[0], list):
-            for cmd_line in cmd: # Execute each line in sequence.
-                rc = subprocess.call(cmd_line)
-                # Stop if we get an error.  Note that "make" does this *even*
-                # when -k/--keep-going mode is enabled.
-                if rc != 0:
-                    break
-        else:
-            rc = subprocess.call(cmd)
-        adb = audit.finish(cmd=opts.cmd or ' '.join(cmd))
+        for cmd_line in cmd: # Execute each line in sequence.
+            rc = subprocess.call(cmd_line)
+            # Stop if we get an error.  Note that "make" does this *even*
+            # when -k/--keep-going mode is enabled.
+            if rc != 0:
+                break
+        adb = audit.finish(cmd=str(opts.cmd))
         adb['CUSTOM'] = custom_results(opts.custom)
         if opts.depsfile:
             prqs = adb[DB][PREREQS]


### PR DESCRIPTION
Add options to enable far more accurate control, e.g.,
so that we can integrate better with "make" when desired.

The --shell and --shellflags options provide control over the shell
and its flags (just as make's SHELL and .SHELLFLAGS do).

The --multiline option runs each command line in sequence
until a command fails, and then execution stops.
This is how "make" works (even when using
its -k/--keep-going mode) unless make's .ONESHELL is enabled.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>